### PR TITLE
update `mkdocs.yml` with navigation.tabs feature

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,18 +6,21 @@ theme:
   palette:
     primary: black
   features:
-    - navigation.sections
-    - navigation.indexes 
+    - navigation.tabs
+    - navigation.indexes
 
 nav:
-  - Home: index.md
+  - Home:
+    - index.md
+    - ZenGin (G1/G2): zengin/general_info/DirectoryStructure.md
+    - Genome (G3/R1): genome/index.md
   - ZenGin (G1/G2):
     - General information:
       - Directory structure: zengin/general_info/DirectoryStructure.md
-      - VDFS - virtual file system : 
+      - VDFS - virtual file system: 
         - zengin/general_info/vdfs/index.md
-        - GothicVDFS : zengin/tools/GothicVDFS.md
-        - VDFS Tool : zengin/tools/VDFSTool.md
+        - GothicVDFS: zengin/tools/GothicVDFS.md
+        - VDFS Tool: zengin/tools/VDFSTool.md
       - Object persistence: zengin/general_info/ObjectPersistence.md
 
     - Animations: 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,6 +12,7 @@ theme:
 nav:
   - Home:
     - index.md
+    - Getting Started: GettingStarted_ZenGin.md
     - ZenGin (G1/G2): zengin/general_info/DirectoryStructure.md
     - Genome (G3/R1): genome/index.md
   - ZenGin (G1/G2):


### PR DESCRIPTION
Fixes #14 
`navigation.sections` doesn't look good with `tabs` with the current docs structure, so I just replaced it.
I added sections to the Home tree, so they're available as tabs and on the side bar.
![image](https://user-images.githubusercontent.com/34622465/181815098-1bc0696b-3dde-4060-b9cd-9cd0b55fcbcd.png)