### PR TITLE
added permalink icon to headers

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -96,6 +96,8 @@ extra:
 
 
 markdown_extensions:
+  - toc:
+      permalink: 𐌾
   - admonition
   - codehilite
   - footnotes


### PR DESCRIPTION
Fixes #8 
I've used the https://unicode-table.com/en/1033E/ G letter as the permalink icon.