### PR TITLE
added last updated indicator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          # Number of commits to fetch. 0 indicates all history.
+          # Default: 1
+          # 0 is needed for the update time plugin to properly work
+          fetch-depth: 0
       - uses: actions/setup-python@v2
         with:
           python-version: 3.x
-      - run: pip install mkdocs-material 
+      - run: pip install mkdocs-material mkdocs-git-revision-date-localized-plugin
 
       - run: mkdocs gh-deploy --force

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+env:
+  GMC_SHOW_UPDATE_TIME: true
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -13,7 +16,7 @@ jobs:
         with:
           # Number of commits to fetch. 0 indicates all history.
           # Default: 1
-          # 0 is needed for the update time plugin to properly work
+          # 0 is needed for the update time plugin to work properly
           fetch-depth: 0
       - uses: actions/setup-python@v2
         with:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -133,4 +133,8 @@ markdown_extensions:
 
 plugins:
   - git-revision-date-localized:
-      type: timeago
+      enabled: !ENV [GMC_SHOW_UPDATE_TIME, False]
+      type: iso_datetime
+      timezone: Europe/Warsaw
+      exclude:
+        - index.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -107,7 +107,6 @@ nav:
       - genome/index.md
       - Object persistence: genome/ObjectPersistence.md
 
-
 extra:
   social:
     - icon: fontawesome/brands/discord
@@ -116,7 +115,6 @@ extra:
     - icon: fontawesome/brands/github
       link: https://github.com/auronen/gmc
       name: Gothic Modding Comunity Github repository
-
 
 markdown_extensions:
   - toc:
@@ -132,3 +130,7 @@ markdown_extensions:
   - pymdownx.superfences
   - pymdownx.tabbed:
       alternate_style: true
+
+plugins:
+  - git-revision-date-localized:
+      type: timeago

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -132,6 +132,7 @@ markdown_extensions:
       alternate_style: true
 
 plugins:
+  - search
   - git-revision-date-localized:
       enabled: !ENV [GMC_SHOW_UPDATE_TIME, False]
       type: iso_datetime


### PR DESCRIPTION
https://timvink.github.io/mkdocs-git-revision-date-localized-plugin/options/
I've tried out `type: timeago` and I think that it would look weird with `2 years ago`.  
I'm not sure whether `iso_datetime` is better than `iso_date` as it shows the `4AM` update time 🤣 
I've set it up to only show the time in the deployed site.