### PR TITLE
Expand navigation

### DIFF
--- a/docs/js/extra.js
+++ b/docs/js/extra.js
@@ -36,16 +36,24 @@ function gmcExternalLinks() {
 
 function gmcExpandNavigation() {
     const activeNav = document.querySelector(".md-nav__link--active").parentElement;
-    const toggles = activeNav.querySelectorAll('input[type="checkbox"]');
-    toggles.forEach( t => {
-        if (t.checked) {
-            gmcDebug(`⏩ ${t.id} already checked`);
-            return;
+    const children = activeNav.querySelector("nav > ul").children;
+
+    for (let i = 0; i < children.length; i++) {
+        const toggle = children[i].querySelector('input[type="checkbox"]');
+
+        if (!toggle) {
+            gmcDebug(`⏩ toggle not present`);
+            continue;
         }
 
-        t.checked = true;
-        gmcDebug(`✅ Expanded '${t.id}'`);
-    })
+        if (toggle.checked) {
+            gmcDebug(`⏩ '${toggle.id}' already checked`);
+            continue;
+        }
+
+        toggle.checked = true;
+        gmcDebug(`✅ Expanded '${toggle.id}'`);
+    }
 }
 
 function gmcDebug(message) {

--- a/docs/js/extra.js
+++ b/docs/js/extra.js
@@ -3,6 +3,7 @@
 let gGMC_DEBUG = false;
 
 window.addEventListener("DOMContentLoaded", _ => {
+    gmcExpandNavigation();
     gmcExternalLinks();
 });
 
@@ -31,6 +32,20 @@ function gmcExternalLinks() {
         a.classList.add(className);
         gmcDebug(`✅ Added '${className}' class to ${a.href}`);
     });
+}
+
+function gmcExpandNavigation() {
+    const activeNav = document.querySelector(".md-nav__link--active").parentElement;
+    const toggles = activeNav.querySelectorAll('input[type="checkbox"]');
+    toggles.forEach( t => {
+        if (t.checked) {
+            gmcDebug(`⏩ ${t.id} already checked`);
+            return;
+        }
+
+        t.checked = true;
+        gmcDebug(`✅ Expanded '${t.id}'`);
+    })
 }
 
 function gmcDebug(message) {


### PR DESCRIPTION
The `navigation.expand` material mkdocs feature expands all tree branches, which isn't ideal.  
I've added a javascript function which expands the 2nd level under the currently selected branch.
Before: 
![image](https://user-images.githubusercontent.com/34622465/182059720-54b545e6-39ae-4942-a9e8-aefe56a43ce9.png)
After:
![image](https://user-images.githubusercontent.com/34622465/182059754-95f05cb9-c15a-4929-81af-0df4a06e69ea.png)
