### PR TITLE
added mkdocs-video plugin, fixed youtube centering

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,8 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: 3.x
-      - run: pip install mkdocs-material mkdocs-git-revision-date-localized-plugin
+      - run: pip install mkdocs-material
+      - run: pip install mkdocs-git-revision-date-localized-plugin
+      - run: pip install mkdocs-video
 
       - run: mkdocs gh-deploy --force

--- a/docs/css/extra.css
+++ b/docs/css/extra.css
@@ -21,3 +21,11 @@
     max-width: 100%;
   }
 }
+
+/* 16:9 aspect ratio and centering */
+/* Works on top of mkdocs-video */
+.video-container {
+  width: 32rem;
+  height: 18rem;
+  margin: auto;
+}

--- a/docs/zengin/anims/MDS.md
+++ b/docs/zengin/anims/MDS.md
@@ -14,7 +14,7 @@ You will see a lot of long and scary code, but it is actually very simple, lets 
     
     To play the animation in game you use this console command `play ani t_yes`.
 
-   <center><iframe width="560" height="315" src="https://www.youtube.com/embed/aOyuGVWDefc" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></center>
+    ![type:video](https://www.youtube.com/embed/aOyuGVWDefc)
 
     
 ## Syntax and keywords

--- a/docs/zengin/anims/StandaloneAni.md
+++ b/docs/zengin/anims/StandaloneAni.md
@@ -27,17 +27,17 @@ A windows pops up, you can read some interesting information about the model you
 
 Click import and wait for the magic to happen.
 
-<center><iframe width="560" height="315" src="https://www.youtube.com/embed/UKltt7mOfj0" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></center>
+![type:video](https://www.youtube.com/embed/UKltt7mOfj0)
 
 This video shows a freshly imported model with all default meshes.
 
 !!! note
     Now if we wanted to play (or edit) existing animation, we can now load it on top of this. Just do as before **File > Import > Kerrax ASCII model (.asc)** and select different animation file (or armour file) for example `Hum_SmokeHerb_Layer_M01.asc` for an animation file.
-    <center><iframe width="560" height="315" src="https://www.youtube.com/embed/FDicnSwhv0w" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></center>
+    ![type:video](https://www.youtube.com/embed/FDicnSwhv0w)    
 
 Gothic characters are modular, you can change their heads on the fly (during gameplay even, as seen in this amazing video of my dear friend and colleague Fawkes - [Head changing](https://www.youtube.com/watch?v=2GBmpeyqKIA)), let's add a head, so we can see how the whole body will behave while we are animating. **File > Import > Kerrax ASCII model (.asc)** and navigate to your head model (for this, you will have to decompile it, like we did with the body itself). I will import `HUM_HEAD_PONY.ASC`. Please make sure to select the target bone for importing **Bip01 Head**, this will attach the head to the proper bone, just like the engine does it.
 
-<center><iframe width="560" height="315" src="https://www.youtube.com/embed/AzotIDHFCSo" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></center>
+![type:video](https://www.youtube.com/embed/AzotIDHFCSo)
 
 Now we have everything ready to start animating. The video shows the DopeSheet a nice way to edit keyframes.
 
@@ -49,7 +49,7 @@ We can import an animation into Blender as a base.
 !!! tip
     If you don't know, what the animation is called, just go into the game, and make your character to perform the animation you want, while in MARVIN mode, you can press `G` and the animation information (and some other info too) will be displayed right on the screen
 
-<center><iframe width="560" height="315" src="https://www.youtube.com/embed/boUwngFLA-U" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></center>
+![type:video](https://www.youtube.com/embed/boUwngFLA-U)
 
 In this video you can see, that the idle standing animation is `s_run`. Because we want to make an animation, that is going to start from this idle animation, we will import it into blender. Where do we find it? Just look into the `.mds` file, look for `s_run` name and get the name of the file.
 ```c++
@@ -59,8 +59,7 @@ As we can see, we have to import the `Hum_RunAmbient_M01.asc` file.
 
 Next goes the first trick. Since we want our animation to end exactly, as it started - wither because we want the hero to continue his standing animation, or we want to make a looping animation we somehow have to copy the pose. I use the DopeSheet screen, to delete all keyframes and then copy the keyframe set from keyframe number 0 and then drag it somewhere to the end of the timeline.
 
-<center><iframe width="560" height="315" src="https://www.youtube.com/embed/2vOMrM-9aWc" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></center>
-
+![type:video](https://www.youtube.com/embed/2vOMrM-9aWc)
 
 Once the animation is done, we have to export it into a `asc` format again, **File > Export > Kerrax ASCII model (.asc)** and then save it to `_work\data\Anims\asc\` so the engine can see it and convert it.
 There are many options here, that we will explore later, but we have tick **Export animation** and pick bones that we want to export - this is useful for animations that are played on different layers (dialoge gestures, scratching head, scratching a shoulder,...).
@@ -82,7 +81,7 @@ ani ("t_backpain" 1 "" 0.0 0.0 M. "Hum_back.ASC" F 0 121)
 Save the `Humans.mds` file and try it in game. Nothing happens! The reason is, the `mds` has been already compiled, and we have to recompile it. The easiest is to go to `Anims\_compiled` and delete `HUMANS.MSB`.
 Run the game and try to play the animation again (`play ani t_backpain` in MARVIN console) now everything should work.
 
-<center><iframe width="560" height="315" src="https://www.youtube.com/embed/-i2un91x1UI" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></center>
+![type:video](https://www.youtube.com/embed/-i2un91x1UI)
 
 Amazing, now you have your first animation in the game. And you can use it to do some fun stuff, like in dialogues using the `AI_PlayAni` function.
 
@@ -115,8 +114,7 @@ func void DIA_Xardas_Back_Info () {
 };
 ```
 
-<center><iframe width="560" height="315" src="https://www.youtube.com/embed/G14lgjA49wU" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></center>
-
+![type:video](https://www.youtube.com/embed/G14lgjA49wU)
 
 
 

--- a/docs/zengin/union_plugins/zParserExtender/zPE_externals.md
+++ b/docs/zengin/union_plugins/zParserExtender/zPE_externals.md
@@ -1,7 +1,7 @@
 # External functions
 External functions are Daedalus functions (defined in the engine itself) used to interface with the enigne. zParseExtender adds quite a huge amount of new functions, that help scripters to interface with the engine in more ways, that was possible before (without script extenders such as Ikarus and LeGo).
 
-## CAST - data type conversion functions
+## CAST data type conversion functions
 External functions for data type conversion and pointer casting.
 
 ```c++
@@ -44,7 +44,7 @@ func int Cast_CheckVobClassID( var int classId, var instance object ) {};
 
 
 
-## HLP - help functions
+## HLP help functions
 Helper functions, used for safety checks or to get specific information from the engine.
 
 
@@ -89,7 +89,7 @@ func void Hlp_WriteOptionString(var string optName, var string section, var stri
 
 
 
-## WLD - world manipulation functions
+## WLD world manipulation functions
 Functions related to the world. 
 
 
@@ -123,7 +123,7 @@ func int Wld_GetWeatherType() {};
 
 
 
-## MDL - model functions
+## MDL model functions
 Functions to tweak animation and other model related settings.
 
 
@@ -169,7 +169,7 @@ func void Mdl_ResetNpcSpeedMultiplier( var C_Npc npc ) {};
 
 
 
-## NPC - character functions
+## NPC character functions
 NPC realted functions.
 
 
@@ -221,7 +221,7 @@ func void Npc_RemoveFromSlot(var C_Npc npc, var string slotName, var int dropIt)
 
 
 
-## MOB - interactive object functions
+## MOB interactive object functions
 Functions to manipulate interactive objects like destroying MOBs, setting lockpick combination and such.
 
 
@@ -253,7 +253,7 @@ func void Mob_SetKeyInstance( var instance object, var int key ) {};
 
 
 
-## AI - functions for working with AI
+## AI functions for working with AI
 Functions to work with the new `C_Trigger` class and NPC's AI queue.
 
 
@@ -305,7 +305,7 @@ func string Hlp_GetSteamPersonalName() {};
 
 
 
-## PAR - functions for parser manipulation
+## PAR functions for parser manipulation
 Parser functions are used to manipulate the parsers. Retrieve SymbolID, access arrays and such.
 
 
@@ -347,7 +347,7 @@ func void Par_SetSymbolValueFloatArray(var float value, var int parId, var int s
 func void Par_SetSymbolValueStringArray(var string value, var int parId, var int symId, var int arrayId) {};
 ```
 
-## VOB - functions for object manipulation
+## VOB functions for object manipulation
 VOB functions allow you to manipulate game world objects.
 ```c++
 /// Returns the current position of the object in the world

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -163,6 +163,10 @@ markdown_extensions:
 
 plugins:
   - search
+  - mkdocs-video:
+      css_style:
+        width: "100%"
+        height: "100%"
   - git-revision-date-localized:
       enabled: !ENV [GMC_SHOW_UPDATE_TIME, False]
       type: iso_datetime


### PR DESCRIPTION
Continuing #23
Added a new plugin that makes writing embedded video links a little bit less cumbersome.  
Added css to enlarge the video and center it.

I've also fixed this issue again, via removing the `-`
https://github.com/auronen/gmc/blob/36efe417b51e0002c1ce2151a44f3e29284cb90a/docs/zengin/union_plugins/zParserExtender/zPE_externals.md?plain=1#L47 
Using a `-` in the heading breaks the anchor in the IDE `.md` preview.  
I could try to fix it another way, but this seems the most convenient 😄 